### PR TITLE
Patch 0.3.2.post1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ omit =
     */experimental/*
     */compat/*
     */hyper/*
+    */type.py
 
 [report]
 exclude_lines =

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.7"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
     - '.gitignore'
 
   pull_request:
-    branches: [master]
+    types: [opened, edited]
     paths-ignore:
       - 'docs/**'
       - 'static/**'

--- a/reservoirpy/_base.py
+++ b/reservoirpy/_base.py
@@ -618,17 +618,17 @@ class _Node(ABC):
     def __call__(self, *args, **kwargs) -> np.ndarray:
         return self.call(*args, **kwargs)
 
-    def __rshift__(self, other: Union["_Node", Sequence["_Node"]]) -> "_Node":
+    def __rshift__(self, other: Union["_Node", Sequence["_Node"]]) -> "Model":
         from .ops import link
 
         return link(self, other)
 
-    def __rrshift__(self, other: Union["_Node", Sequence["_Node"]]) -> "_Node":
+    def __rrshift__(self, other: Union["_Node", Sequence["_Node"]]) -> "Model":
         from .ops import link
 
         return link(other, self)
 
-    def __and__(self, other: Union["_Node", Sequence["_Node"]]) -> "_Node":
+    def __and__(self, other: Union["_Node", Sequence["_Node"]]) -> "Model":
         from .ops import merge
 
         return merge(self, other)

--- a/reservoirpy/_version.py
+++ b/reservoirpy/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.2"
+__version__ = "0.3.2.post1"

--- a/reservoirpy/model.py
+++ b/reservoirpy/model.py
@@ -773,7 +773,7 @@ class Model(_Node):
             A sequence of input data.
             If dict, then pairs of keys and values, where keys are Model input
             nodes names and values are sequence of input data.
-        forced_feedback: dict of array-like of shape ([n_feedbacks], timesteps, feedabck_dim)
+        forced_feedbacks: dict of array-like of shape ([n_feedbacks], timesteps, feedabck_dim)
             Pairs of keys and values, where keys are Model nodes names and
             value are sequences of feedback vectors to force into the nodes.
         from_state : dict of arrays of shape ([nodes], 1, nodes.output_dim)

--- a/reservoirpy/node.py
+++ b/reservoirpy/node.py
@@ -220,6 +220,8 @@ def _partial_backward_default(node, X_batch, Y_batch=None):
         else:
             node._Y.extend(Y_batch)
 
+    return
+
 
 def _initialize_feedback_default(node, fb):
     """Void feedback initializer. Works in any case."""
@@ -369,12 +371,12 @@ class Node(_Node):
 
         self._fitted = False if self.is_trainable and self.is_trained_offline else True
 
-        self._X = self._Y = []
+        self._X, self._Y = [], []
 
-    def __lshift__(self, other):
+    def __lshift__(self, other) -> "_Node":
         return self.link_feedback(other)
 
-    def __ilshift__(self, other):
+    def __ilshift__(self, other) -> "_Node":
         return self.link_feedback(other, inplace=True)
 
     def __iand__(self, other):

--- a/reservoirpy/nodes/reservoirs/intrinsic_plasticity.py
+++ b/reservoirpy/nodes/reservoirs/intrinsic_plasticity.py
@@ -3,7 +3,7 @@
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
 import sys
 
-if sys.version_info <= (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/reservoirpy/nodes/reservoirs/intrinsic_plasticity.py
+++ b/reservoirpy/nodes/reservoirs/intrinsic_plasticity.py
@@ -1,8 +1,15 @@
 # Author: Nathan Trouvain at 16/08/2021 <nathan.trouvain@inria.fr>
 # Licence: MIT License
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
+import sys
+
+if sys.version_info <= (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
 from functools import partial
-from typing import Callable, Literal, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 
 import numpy as np
 

--- a/reservoirpy/nodes/reservoirs/reservoir.py
+++ b/reservoirpy/nodes/reservoirs/reservoir.py
@@ -3,7 +3,7 @@
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
 import sys
 
-if sys.version_info <= (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/reservoirpy/nodes/reservoirs/reservoir.py
+++ b/reservoirpy/nodes/reservoirs/reservoir.py
@@ -1,8 +1,15 @@
 # Author: Nathan Trouvain at 16/08/2021 <nathan.trouvain@inria.fr>
 # Licence: MIT License
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
+import sys
+
+if sys.version_info <= (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
 from functools import partial
-from typing import Callable, Literal, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 
 from ...activationsfunc import get_function, identity, tanh
 from ...mat_gen import bernoulli, normal

--- a/reservoirpy/observables.py
+++ b/reservoirpy/observables.py
@@ -17,7 +17,12 @@ Metrics and observables for Reservoir Computing:
 # Author: Nathan Trouvain at 01/06/2021 <nathan.trouvain@inria.fr>
 # Licence: MIT License
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
-from typing import Literal
+import sys
+
+if sys.version_info <= (3, 7):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 import numpy as np
 from scipy import linalg

--- a/reservoirpy/observables.py
+++ b/reservoirpy/observables.py
@@ -19,7 +19,7 @@ Metrics and observables for Reservoir Computing:
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
 import sys
 
-if sys.version_info <= (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/reservoirpy/ops.py
+++ b/reservoirpy/ops.py
@@ -24,7 +24,6 @@ from uuid import uuid4
 
 from ._base import DistantFeedback, _Node
 from .model import FrozenModel, Model
-from .node import Node
 from .nodes.concat import Concat
 
 
@@ -215,7 +214,7 @@ def link(
 
 
 def link_feedback(
-    node: Node,
+    node: _Node,
     feedback: Union[_Node, Sequence[_Node]],
     inplace: bool = False,
     name: str = None,
@@ -313,7 +312,7 @@ def link_feedback(
 
 def merge(
     model: _Node, *models: _Node, inplace: bool = False, name: str = None
-) -> _Node:
+) -> Model:
     """Merge different :py:class:`~.Model` or :py:class:`~.Node`
     instances into a single :py:class:`~.Model` instance.
 

--- a/reservoirpy/ops.py
+++ b/reservoirpy/ops.py
@@ -180,7 +180,7 @@ def link(
         frozens += [n.name for n in node2 if isinstance(n, FrozenModel)]
     else:
         if isinstance(node2, FrozenModel):
-            frozens.append(2)
+            frozens.append(node2)
 
     if len(frozens) > 0:
         raise TypeError(

--- a/reservoirpy/utils/__init__.py
+++ b/reservoirpy/utils/__init__.py
@@ -30,7 +30,7 @@ def safe_defaultdict_copy(d):
         if isinstance(item, Iterable):
             new_d[key] = list(item)
         else:
-            new_d[key] += item
+            new_d[key] += [item]
     return new_d
 
 

--- a/reservoirpy/utils/model_utils.py
+++ b/reservoirpy/utils/model_utils.py
@@ -42,10 +42,7 @@ def _dist_states_to_next_subgraph(states, relations):
 
 def _allocate_returned_states(model, inputs, return_states=None):
 
-    if is_mapping(inputs):
-        seq_len = inputs[list(inputs.keys())[0]].shape[0]
-    else:
-        seq_len = inputs.shape[0]
+    seq_len = inputs[list(inputs.keys())[0]].shape[0]
 
     # pre-allocate states
     if return_states == "all":

--- a/reservoirpy/utils/random.py
+++ b/reservoirpy/utils/random.py
@@ -2,11 +2,10 @@
 # Licence: MIT License
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
 from functools import partial
-from typing import Callable, Union
+from typing import Union
 
 import numpy as np
 from numpy.random import MT19937, Generator, RandomState, default_rng
-from scipy import stats
 
 __SEED = None
 __global_rg = default_rng()
@@ -18,6 +17,7 @@ def set_seed(seed):
     if type(seed) is int:
         __SEED = seed
         __global_rg = default_rng(__SEED)
+        np.random.seed(__SEED)
     else:
         raise TypeError(f"Random seed must be an integer, not {type(seed)}")
 
@@ -40,58 +40,9 @@ def rand_generator(seed: Union[int, Generator, RandomState] = None) -> Generator
         return default_rng(seed)
 
 
-# def get_rvs(dist: str, seed=None, **kwargs) -> Callable:
-#     # override scipy.stats uniform rvs
-#     # to allow user to set the distribution with
-#     # common low/high values and not loc/scale
-#     rng = rand_generator(seed)
-#
-#     if dist == "uniform":
-#         return _uniform_rvs(**kwargs, random_state=rng)
-#     elif dist == "bimodal":
-#         return _bimodal_discrete_rvs(**kwargs, random_state=rng)
-#     elif dist in dir(stats):
-#         distribution = getattr(stats, dist)
-#         return partial(distribution(**kwargs).rvs, random_state=rng)
-#     else:
-#         raise ValueError(
-#             f"'{dist}' is not a valid distribution name. "
-#             "See 'scipy.stats' for all available distributions."
-#         )
-
-
-# def _bimodal_discrete_rvs(
-#     value: float = 1.0, random_state: Union[Generator, int] = None
-# ) -> Callable:
-#     def rvs(size: int = 1):
-#         return random_state.choice([value, -value], replace=True, size=size)
-#
-#     return rvs
-
-
-# def _uniform_rvs(
-#     low: float = -1.0, high: float = 1.0, random_state: Union[Generator, int] = None
-# ) -> Callable:
-#
-#     distribution = getattr(stats, "uniform")
-#     return partial(
-#         distribution(loc=low, scale=high - low).rvs, random_state=random_state
-#     )
-
-
 def noise(dist="normal", shape=1, gain=1.0, seed=None, **kwargs):
     if gain > 0.0 or gain < 0.0:
         rng = rand_generator(seed)
         return gain * getattr(rng, dist)(**kwargs, size=shape)
     else:
         return np.zeros(shape)
-
-
-# def normal_noise(shape=1, gain=1.0, loc=0.0, scale=1.0, seed=None):
-#     rng = rand_generator(seed)
-#     return gain * rng.normal(loc, scale, size=shape)
-#
-#
-# def uniform_noise(shape=1, gain=1.0, low=0.0, high=1.0, seed=None):
-#     rng = rand_generator(seed)
-#     return gain * rng.uniform(low, high, size=shape)

--- a/reservoirpy/utils/random.py
+++ b/reservoirpy/utils/random.py
@@ -1,7 +1,6 @@
 # Author: Nathan Trouvain at 06/07/2021 <nathan.trouvain@inria.fr>
 # Licence: MIT License
 # Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
-from functools import partial
 from typing import Union
 
 import numpy as np
@@ -41,7 +40,7 @@ def rand_generator(seed: Union[int, Generator, RandomState] = None) -> Generator
 
 
 def noise(dist="normal", shape=1, gain=1.0, seed=None, **kwargs):
-    if gain > 0.0 or gain < 0.0:
+    if abs(gain) > 0.0:
         rng = rand_generator(seed)
         return gain * getattr(rng, dist)(**kwargs, size=shape)
     else:

--- a/reservoirpy/utils/tests/test_random.py
+++ b/reservoirpy/utils/tests/test_random.py
@@ -1,0 +1,44 @@
+# Author: Nathan Trouvain at 25/03/2022 <nathan.trouvain@inria.fr>
+# Licence: MIT License
+# Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from reservoirpy.utils.random import noise, rand_generator, set_seed
+
+
+def test_set_seed():
+    set_seed(45)
+    from reservoirpy.utils.random import __SEED
+
+    assert __SEED == 45
+
+    with pytest.raises(TypeError):
+        set_seed("foo")
+
+
+def test_random_generator_cast():
+
+    gen1 = np.random.RandomState(123)
+    gen2 = rand_generator(gen1)
+
+    assert isinstance(gen2, np.random.Generator)
+
+
+def test_random_generator_from_seed():
+
+    gen1 = rand_generator(123)
+    gen2 = np.random.default_rng(123)
+
+    assert gen1.integers(1000) == gen2.integers(1000)
+
+
+def test_noise():
+    a = noise(gain=0.0)
+    assert_equal(a, np.zeros((1,)))
+
+    a = noise(dist="uniform", gain=2.0, seed=123)
+    b = 2.0 * np.random.default_rng(123).uniform()
+
+    assert_equal(a, b)

--- a/reservoirpy/utils/tests/test_utils.py
+++ b/reservoirpy/utils/tests/test_utils.py
@@ -1,0 +1,80 @@
+# Author: Nathan Trouvain at 25/03/2022 <nathan.trouvain@inria.fr>
+# Licence: MIT License
+# Copyright: Xavier Hinaut (2018) <xavier.hinaut@inria.fr>
+from collections import defaultdict
+
+import pytest
+from tqdm import tqdm
+
+from reservoirpy.utils import (
+    _obj_from_kwargs,
+    progress,
+    safe_defaultdict_copy,
+    verbosity,
+)
+
+
+def test_verbosity():
+    v = verbosity()
+    from reservoirpy.utils import VERBOSITY
+
+    assert v == VERBOSITY
+    verbosity(0)
+    from reservoirpy.utils import VERBOSITY
+
+    assert VERBOSITY == 0
+
+
+def test_progress():
+    verbosity(0)
+    a = [1, 2, 3]
+    it = progress(a)
+    assert id(it) == id(a)
+
+    verbosity(1)
+    it = progress(a)
+    assert isinstance(it, tqdm)
+
+
+def test_defaultdict_copy():
+
+    a = defaultdict(list)
+
+    a["a"].extend([1, 2, 3])
+    a["b"] = 2
+
+    b = safe_defaultdict_copy(a)
+
+    assert list(b.values()) == [
+        [1, 2, 3],
+        [
+            2,
+        ],
+    ]
+    assert list(b.keys()) == ["a", "b"]
+
+    a = dict()
+
+    a["a"] = [1, 2, 3]
+    a["b"] = 2
+
+    b = safe_defaultdict_copy(a)
+
+    assert list(b.values()) == [
+        [1, 2, 3],
+        [
+            2,
+        ],
+    ]
+    assert list(b.keys()) == ["a", "b"]
+
+
+def test_obj_from_kwargs():
+    class A:
+        def __init__(self, a=0, b=2):
+            self.a = a
+            self.b = b
+
+    a = _obj_from_kwargs(A, {"a": 1})
+    assert a.a == 1
+    assert a.b == 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ testpaths =
     reservoirpy/compat/tests
     reservoirpy/datasets/tests
     reservoirpy/experimental/tests
+    reservoirpy/utils/tests


### PR DESCRIPTION
## Bug fix
- Fix feedback in `Model`: forced vectors were not used if they were adresses to sender.
- Fix import error of `typing.Literal` with Python < 3.8 (#65)
- Fix random seed: `reservoirpy.set_seed` was not fixing Numpy random seed.
- Fix frozen model list building in `ops.link`.
- Fix problem with private data containers `_X` and `_Y`  for `Node.fit` that were mirroring themselves.

## Other changes
- Improve coverage in `reservoirpy.utils`
- Add Python 3.7 in test matrix for GitHub runner.
- Fix typing issues with Model built from linking or merging of nodes (not recognized as a Model by IDEs)