### PR TITLE
Deterministic SR calculation for sparse reservoir

### DIFF
--- a/reservoirpy/observables.py
+++ b/reservoirpy/observables.py
@@ -86,7 +86,7 @@ def spectral_radius(W: Weights, maxiter: int = None) -> float:
             maxiter = W.shape[0] * 20
 
         return max(
-            abs(eigs(W, k=1, which="LM", maxiter=maxiter, return_eigenvectors=False))
+            abs(eigs(W, k=1, which="LM", maxiter=maxiter, return_eigenvectors=False, v0=np.ones(W.shape[0], W.dtype)))
         )
 
     return max(abs(linalg.eig(W)[0]))


### PR DESCRIPTION
The calculation of the spectral radius of a sparse reservoir (i.e. its weight matrix) uses scipy.sparse.linalg.eigs, which gives a non-deterministic approximation of the matrix eigenvalues, unless the `v0` parameter is specified.

Right now, because the reservoir creation with a specified SR depends on scipy.sparse.linalg.eigs, two reservoirs created with the same seed and parameters can have close-to-machine-precision differences.

This PR should fix this issue