### PR TITLE
added history to mackey_glass

### DIFF
--- a/reservoirpy/datasets/tests/test_datasets.py
+++ b/reservoirpy/datasets/tests/test_datasets.py
@@ -51,6 +51,8 @@ def test_generation(dataset_func):
         (datasets.mackey_glass, {"seed": 1234}, None),
         (datasets.mackey_glass, {"seed": None}, None),
         (datasets.mackey_glass, {"tau": 0}, None),
+        (datasets.mackey_glass, {"history": np.ones((20,))}, None),
+        (datasets.mackey_glass, {"history": np.ones((10,))}, ValueError),
         (datasets.narma, {"seed": 1234}, None),
         (datasets.lorenz96, {"N": 1}, ValueError),
         (datasets.lorenz96, {"x0": [0.1, 0.2, 0.3, 0.4, 0.5], "N": 4}, ValueError),


### PR DESCRIPTION
Currently, delayed differential equations (DDE) such as Mackey-Glass are initialized with random history. Yet, for certain tasks, it is desirable to directly set the history. Consider estimating the Lyapunov exponent, for instance. One may want to generate two trajectories with initial conditions $d_0$ apart. The initial condition of DDE, however, also includes the historical record of the process. Thus, a correct setup must use the following definition of distance:

$\textbf d^2_{ij} = \frac{1}{\tau}\int_ {t=-\tau}^0 || \textbf{x}_i(t) - \textbf{x}_j(t) ||^2 dt$

which in discrete case translates into:

$\textbf d^2_{ij} = \Big[ \delta x[0]^2 + (  \delta x[-1]^2 + \delta x[-2]^2 + ... + \delta x[-\tau/dt]^2 )  \Big] $

This PR provides the possibility to directly provide the historical sequence to the `mackey_glass` process via an argument `history`. It asserts the length of the provided array. If it is long enough, enqueues the most recent elements to the `history` queue, otherwise and error will be raised. The default is set to `None` which initializes history randomly, as usual. 