### PR TITLE
Add forgetting factor to RLS

### DIFF
--- a/reservoirpy/nodes/readouts/force.py
+++ b/reservoirpy/nodes/readouts/force.py
@@ -48,6 +48,8 @@ class FORCE(Node):
                        default).
     ``input_bias``     If True, learn a bias term (True by default).
     ``rule``           One of RLS or LMS rule ("rls" by default).
+     ``forgetting``    Forgetting factor, only used with RLS (:math:`\\forgetting`) 
+                       (:math:`1` by default).
     ================== =================================================================
 
     Parameters
@@ -75,6 +77,8 @@ class FORCE(Node):
         the returned weight matrix.
     input_bias : bool, default to True
         If True, then a bias parameter will be learned along with output weights.
+    forgetting : float, default to 1.0
+        Forgetting factor for the RLS rule. Ignored if rule is "lms".
     name : str, optional
         Node name.
 
@@ -99,6 +103,7 @@ class FORCE(Node):
         Wout=zeros,
         bias=zeros,
         input_bias=True,
+        forgetting=1.0,
         name=None,
     ):
 
@@ -138,15 +143,24 @@ class FORCE(Node):
             raise TypeError(
                 "'alpha' parameter should be a float or an iterable yielding floats."
             )
+        
+        hypers = {
+            "alpha": alpha,
+            "_alpha_gen": alpha_gen,
+            "input_bias": input_bias,
+            "rule": rule,
+        }
+
+        if rule == "rls":
+            if not isinstance(forgetting, Number):
+                raise TypeError(
+                    "'forgetting' parameter should be a float."
+                )
+            hypers["forgetting"] = forgetting
 
         super(FORCE, self).__init__(
             params=params,
-            hypers={
-                "alpha": alpha,
-                "_alpha_gen": alpha_gen,
-                "input_bias": input_bias,
-                "rule": rule,
-            },
+            hypers=hypers,
             forward=readout_forward,
             train=train,
             initializer=partial(

--- a/reservoirpy/nodes/readouts/force.py
+++ b/reservoirpy/nodes/readouts/force.py
@@ -48,7 +48,7 @@ class FORCE(Node):
                        default).
     ``input_bias``     If True, learn a bias term (True by default).
     ``rule``           One of RLS or LMS rule ("rls" by default).
-     ``forgetting``    Forgetting factor, only used with RLS (:math:`\\forgetting`) 
+     ``forgetting``    Forgetting factor, only used with RLS (:math:`\\lambda`) 
                        (:math:`1` by default).
     ================== =================================================================
 

--- a/reservoirpy/nodes/readouts/rls.py
+++ b/reservoirpy/nodes/readouts/rls.py
@@ -22,12 +22,11 @@ def _rls(P, r, e, f):
     f = float(f)    
     k = np.dot(P, r)
     rPr = np.dot(r.T, k).squeeze()
-    c0 = float(1.0 / (1.0 + rPr))
     c1 = float(1.0 / (f*(f + rPr)))
     c2 = float(1.0 / f)
     P = c2*P - c1 * np.outer(k, k)
-    dw = -c0*np.outer(e, k)
-
+    dw = -np.outer(e,np.dot(P, r))
+    
     return dw, P
 
 


### PR DESCRIPTION
Added the forgetting factor to the RLS algorithm, based on equations from Waegeman et al. (2012) in "Feedback Control by Online Learning an Inverse Model" (IEEE Transactions on Neural Networks and Learning Systems).