### PR TITLE
Adding forgetting factor to RLS equation

### DIFF
--- a/reservoirpy/nodes/readouts/force.py
+++ b/reservoirpy/nodes/readouts/force.py
@@ -48,6 +48,8 @@ class FORCE(Node):
                        default).
     ``input_bias``     If True, learn a bias term (True by default).
     ``rule``           One of RLS or LMS rule ("rls" by default).
+     ``forgetting``    Forgetting factor, only used with RLS (:math:`\\lambda`) 
+                       (:math:`1` by default).
     ================== =================================================================
 
     Parameters
@@ -75,6 +77,8 @@ class FORCE(Node):
         the returned weight matrix.
     input_bias : bool, default to True
         If True, then a bias parameter will be learned along with output weights.
+    forgetting : float, default to 1.0
+        Forgetting factor for the RLS rule. Ignored if rule is "lms".
     name : str, optional
         Node name.
 
@@ -99,6 +103,7 @@ class FORCE(Node):
         Wout=zeros,
         bias=zeros,
         input_bias=True,
+        forgetting=1.0,
         name=None,
     ):
 
@@ -138,15 +143,24 @@ class FORCE(Node):
             raise TypeError(
                 "'alpha' parameter should be a float or an iterable yielding floats."
             )
+        
+        hypers = {
+            "alpha": alpha,
+            "_alpha_gen": alpha_gen,
+            "input_bias": input_bias,
+            "rule": rule,
+        }
+
+        if rule == "rls":
+            if not isinstance(forgetting, Number):
+                raise TypeError(
+                    "'forgetting' parameter should be a float."
+                )
+            hypers["forgetting"] = forgetting
 
         super(FORCE, self).__init__(
             params=params,
-            hypers={
-                "alpha": alpha,
-                "_alpha_gen": alpha_gen,
-                "input_bias": input_bias,
-                "rule": rule,
-            },
+            hypers=hypers,
             forward=readout_forward,
             train=train,
             initializer=partial(

--- a/reservoirpy/nodes/readouts/rls.py
+++ b/reservoirpy/nodes/readouts/rls.py
@@ -17,15 +17,16 @@ from .base import (
 )
 
 
-def _rls(P, r, e):
-    """Recursive Least Squares learning rule."""
+def _rls(P, r, e, f):
+    """Recursive Least Squares learning rule with forgetting factor."""
+    f = float(f)    
     k = np.dot(P, r)
     rPr = np.dot(r.T, k).squeeze()
-    c = float(1.0 / (1.0 + rPr))
-    P = P - c * np.outer(k, k)
-
-    dw = -c * np.outer(e, k)
-
+    c1 = float(1.0 / (f*(f + rPr)))
+    c2 = float(1.0 / f)
+    P = c2*P - c1 * np.outer(k, k)
+    dw = -np.outer(e,np.dot(P, r))
+    
     return dw, P
 
 
@@ -36,7 +37,7 @@ def train(node: "RLS", x, y=None):
     error, r = _compute_error(node, x, y)
 
     P = node.P
-    dw, P = _rls(P, r, error)
+    dw, P = _rls(P, r, error, node.forgetting)
     wo = _assemble_wout(node.Wout, node.bias, node.input_bias)
     wo = wo + dw.T
 
@@ -48,6 +49,7 @@ def train(node: "RLS", x, y=None):
 def initialize(
     readout: "RLS", x=None, y=None, init_func=None, bias_init=None, bias=None
 ):
+
     _initialize_readout(readout, x, y, init_func, bias_init, bias)
 
     if x is not None:
@@ -66,6 +68,7 @@ class RLS(Node):
     algorithm.
 
     The learning rules is well described in [1]_.
+    The forgetting factor version of the RLS algorithm used here is described in [2]_.
 
     :py:attr:`RLS.params` **list**
 
@@ -80,6 +83,7 @@ class RLS(Node):
     ================== =================================================================
     ``alpha``          Diagonal value of matrix P (:math:`\\alpha`) (:math:`1\\cdot 10^{-6}` by default).
     ``input_bias``     If True, learn a bias term (True by default).
+    ``forgetting``     Forgetting factor (:math:`\\lambda`) (:math:`1` by default).  
     ================== =================================================================
 
     Parameters
@@ -100,6 +104,9 @@ class RLS(Node):
         the returned weight matrix.
     input_bias : bool, default to True
         If True, then a bias parameter will be learned along with output weights.
+    forgetting : float, default to 1.0
+        The forgetting factor controls the weight given to past observations in the RLS update.
+        A value less than 1.0 gives more weight to recent observations.
     name : str, optional
         Node name.
 
@@ -109,6 +116,10 @@ class RLS(Node):
     .. [1] Sussillo, D., & Abbott, L. F. (2009). Generating Coherent Patterns of
            Activity from Chaotic Neural Networks. Neuron, 63(4), 544–557.
            https://doi.org/10.1016/j.neuron.2009.07.018
+
+    .. [2] Waegeman, T., Wyffels, F., & Schrauwen, B. (2012). Feedback Control by Online
+           Learning an Inverse Model. IEEE Transactions on Neural Networks and Learning
+           Systems, 23(10), 1637–1648. https://doi.org/10.1109/TNNLS.2012.2208655
 
     Examples
     --------
@@ -134,6 +145,7 @@ class RLS(Node):
         Wout=zeros,
         bias=zeros,
         input_bias=True,
+        forgetting=1.0,
         name=None,
     ):
         super(RLS, self).__init__(
@@ -141,6 +153,7 @@ class RLS(Node):
             hypers={
                 "alpha": alpha,
                 "input_bias": input_bias,
+                "forgetting": forgetting,
             },
             forward=readout_forward,
             train=train,


### PR DESCRIPTION
Added the forgetting factor to the RLS algorithm, based on equations from Waegeman et al. (2012) in "Feedback Control by Online Learning an Inverse Model" (IEEE Transactions on Neural Networks and Learning Systems).