### PR TITLE
Working with incomplete Y data

### DIFF
--- a/reservoirpy/node.py
+++ b/reservoirpy/node.py
@@ -222,17 +222,12 @@ def _filter_where_na_target(x, y):
     elif x.ndim == 2 and y.ndim == 2:
         is_na = np.any(np.isnan(y), axis=-1)
     else:
-        raise AssertionError(
+        raise ValueError(
             "The dimensions of X_batch and Y_batch do not fit the expected cases."
         )
 
     is_kept = np.logical_not(is_na)
-    idx_kept = np.where(is_kept)[0]
-
-    x = np.take(x, indices=idx_kept, axis=0)
-    y = np.take(y, indices=idx_kept, axis=0)
-
-    return x, y
+    return x[is_kept], y[is_kept]
 
 
 class Node(_Node):


### PR DESCRIPTION
Salut Paul!

I have added a filtering step so when a Node is (partial-)fitted, the incomplete Y values (at least one NA in the features/row), and their corresponding X values  are removed.

In other words:
- the Reservoir still "sees" all the inputs
- but the Readout is fitted using only the complete targets and their corresponding inputs (in the standard case, the Reservoir states)

I have used both pytest and pre-commit.  BTW some files I did not touch were modified by  `pre-commit run -a`, if you want I can push them too.

I can write a specific test for this use case if you want it.