### PR TITLE
Modified the _TEMPDIR variable to generate a unique temporary directory

### DIFF
--- a/reservoirpy/__init__.py
+++ b/reservoirpy/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import random
+import string
 import tempfile
 
 from . import activationsfunc, compat, hyper, mat_gen, nodes, observables, type
@@ -14,7 +16,8 @@ from .utils.random import set_seed
 
 logger = logging.getLogger(__name__)
 
-_TEMPDIR = os.path.join(tempfile.gettempdir(), "reservoirpy-temp")
+# Generate a unique temporary directory to prevent permission errors
+_TEMPDIR = os.path.join(tempfile.gettempdir(), "reservoirpy-temp-" + "".join(random.choices(string.ascii_letters + string.digits, k=8)))
 if not os.path.exists(_TEMPDIR):  # pragma: no cover
     try:
         os.mkdir(_TEMPDIR)


### PR DESCRIPTION
The temporary directory used by ReservoirPy was previously set to `/tmp/reservoirpy-temp`. This could lead to permission errors if multiple users are running ReservoirPy on the same device, as the directory might be shared.

To mitigate this, I modified the temporary directory path to `/tmp/reservoirpy-temp-XXXXXXXX`, where `XXXXXXXX` is a random string. This ensures that each user gets a unique temporary directory, preventing potential permission conflicts.
